### PR TITLE
Enhance release-close for iso purposes.

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -48,12 +48,14 @@ program
   .description('Creates a release from commit or master')
   .option('-f --force-push', 'Pushes local changes to remote')
   .option('-c --close', 'Opens and closes the release creating a tag')
+  .option('-M --no-merge', 'Will not merge after creating tag if called with -c')
   .action(releaseCreate);
 
 program
   .command('release-close [tag]')
   .description('Close a release to master')
   .option('-f --force-push', 'Pushes local changes to remote')
+  .option('-M --no-merge', 'Will not merge after creating tag')
   .action(releaseClose);
 
 program

--- a/src/lib/release-close.ts
+++ b/src/lib/release-close.ts
@@ -9,6 +9,9 @@ export default async function releaseClose(tag, options) {
   const releaseName = getReleaseName(tag);
   await createTag(tag, releaseName);
 
+  if (!options.merge) {
+    return;
+  }
   merge(releaseName, config.BASE_BRANCH);
 
   await pushBranchToRemoteAndDelete(releaseName, options.forcePush);


### PR DESCRIPTION
Release close should not merge locally results because changes must be approved for iso purposes.