### PR TITLE
Use --force-with-lease instead of -f when pushing to remote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1657,12 +1657,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
@@ -1671,6 +1665,12 @@
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",


### PR DESCRIPTION
Git's push `--force` is destructive because it unconditionally overwrites
the remote repository with whatever you have locally, possibly
overwriting any changes that a team member has pushed in the meantime.

The option `--force-with-lease` can do a forced push but still ensure you don't
overwrite other's work.