### PR TITLE
Add indication that branch is pushed to remote upon creation

### DIFF
--- a/src/lib/feature-create.ts
+++ b/src/lib/feature-create.ts
@@ -26,6 +26,7 @@ export default async function featureCreate(branch, options) {
 
 Summary of actions:
  - A new branch '${getCurrentBranch()}' was created, based on '${base}'
+ - The new branch was pushed to remote origin/${getCurrentBranch()}
  - You are now on branch '${getCurrentBranch()}'
 
 Now, start committing on your feature. When done, use:

--- a/src/lib/hotfix-create.ts
+++ b/src/lib/hotfix-create.ts
@@ -18,6 +18,7 @@ export default async function hotfixCreate(branch, tag, options) {
 
 Summary of actions:
  - A new branch ${getCurrentBranch()} was created base on tag ${tag}
+ - The new branch was pushed to remote origin/${getCurrentBranch()}
  - You are now on branch ${getCurrentBranch()}
 
  Now, start committing on your hotfix. When done, use:


### PR DESCRIPTION
Just an indication that the new branch is already pushed to remote.