### PR TITLE
Introduces the bugfix command

### DIFF
--- a/src/lib/bugfix-close.ts
+++ b/src/lib/bugfix-close.ts
@@ -1,0 +1,37 @@
+import * as chalk from 'chalk';
+import { getBranchPrompt, merge, pushBranchToRemoteAndDelete } from './helpers';
+import { getConfig } from './config';
+
+export default async function bugfixClose(branch, options) {
+  branch = await getBranchPrompt(branch);
+
+  const {
+    BASE_BRANCH,
+    MERGE_FF,
+    FEATURE_CLOSE_REWRITE_COMMITS,
+    MERGE_INTERACTIVE,
+    FEATURE_CLOSE_SQUASH,
+    PUSH_CHANGES_TO_REMOTE
+  } = getConfig(options);
+
+  await merge(branch, BASE_BRANCH, {
+    noff: !MERGE_FF,
+    rebase: true,
+    rewriteCommits: FEATURE_CLOSE_REWRITE_COMMITS,
+    interactive: MERGE_INTERACTIVE,
+    squash: FEATURE_CLOSE_SQUASH
+  });
+
+  const pushed = await pushBranchToRemoteAndDelete(branch, PUSH_CHANGES_TO_REMOTE);
+
+  console.log(
+    chalk.blue(`Switched to branch ${getConfig().BASE_BRANCH}
+
+Summary of actions:
+ - Latest changes were fetched from remote
+ - Branch ${branch} was merged into ${getConfig().BASE_BRANCH}
+ ${pushed ? `- Branch ${branch} was deleted and changes were pushed to remote` : ''}
+ - You are now on branch ${getConfig().BASE_BRANCH}
+  `)
+  );
+}

--- a/src/lib/bugfix-create.ts
+++ b/src/lib/bugfix-create.ts
@@ -1,0 +1,36 @@
+import exec, { revert } from './exec';
+import * as chalk from 'chalk';
+import * as inquirer from 'inquirer';
+import { branchName } from './questions';
+import { getCurrentBranch, pushToRemote } from './helpers';
+import { getConfig } from './config';
+
+export default async function bugfixCreate(branch, options) {
+  if (!branch) {
+    ({ branchName: branch } = await inquirer.prompt(branchName()));
+  }
+  const { BASE_BRANCH: base, PUSH_CHANGES_TO_REMOTE } = getConfig(options);
+  const checkoutBranch = options.releaseFrom || base;
+  exec(`git checkout ${checkoutBranch}`);
+  checkoutBranch === base && exec('git pull');
+  exec(`git checkout -b ${branch};`);
+  revert(`git checkout ${base} && git branch -d ${branch}`);
+  await pushToRemote(PUSH_CHANGES_TO_REMOTE, false, branch);
+
+  if (options.log === false) {
+    return;
+  }
+
+  console.log(
+    chalk.blue(`Switched to a new branch ${getCurrentBranch()}
+
+Summary of actions:
+ - A new branch '${getCurrentBranch()}' was created, based on '${base}'
+ - You are now on branch '${getCurrentBranch()}'
+
+Now, start committing on your bugfix. When done, use:
+
+  oneflow bugfix-close ${getCurrentBranch()}
+  `)
+  );
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -49,6 +49,8 @@ export declare type CONFIG = {
   GET_VERSION: string;
   LAST_CHECKED: Date;
   initialized: boolean;
+  BUGFIX_PREFIX: string;
+  FEATURE_PREFIX: string;
 };
 
 export function getConfig(argOptions = {}): CONFIG {

--- a/src/lib/feature-create.ts
+++ b/src/lib/feature-create.ts
@@ -26,6 +26,7 @@ export default async function featureCreate(branch, options) {
 
 Summary of actions:
  - A new branch '${getCurrentBranch()}' was created, based on '${base}'
+ - The new branch was pushed to remote origin/${getCurrentBranch()}
  - You are now on branch '${getCurrentBranch()}'
 
 Now, start committing on your feature. When done, use:

--- a/src/lib/hotfix-create.ts
+++ b/src/lib/hotfix-create.ts
@@ -18,6 +18,7 @@ export default async function hotfixCreate(branch, tag, options) {
 
 Summary of actions:
  - A new branch ${getCurrentBranch()} was created base on tag ${tag}
+ - The new branch was pushed to remote origin/${getCurrentBranch()}
  - You are now on branch ${getCurrentBranch()}
 
  Now, start committing on your hotfix. When done, use:

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -113,6 +113,10 @@ function init() {
 
   taptapCommander.init(program, process.argv[1].split('/').pop());
   program.version(packageJson.version).parse(process.argv);
+
+  if (program.args.length === 0) {
+    program.help();
+  }
 }
 
 init();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,8 @@ import * as program from 'commander';
 import * as taptapCommander from 'commander-tabtab';
 import hotfixCreate from './hotfix-create';
 import hotfixClose from './hotfix-close';
+import bugfixCreate from './bugfix-create';
+import bugfixClose from './bugfix-close';
 import featureCreate from './feature-create';
 import featureClose from './feature-close';
 import releaseCreate from './release-create';
@@ -47,6 +49,22 @@ function init() {
     .addOption('rebase', 'Will rebase to latest hotfix', 'Will not rebase to latest hotfix')
     .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
     .action(wrap(hotfixClose));
+
+  program
+    .command('bugfix-create [branch]')
+    .description('Create locally a bugfix branch from latest master')
+    .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
+    .action(wrap(bugfixCreate));
+
+  program
+    .command('bugfix-close [branch]')
+    .description('Close a bugfix branch to master')
+    .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
+    .addOption('interactive', 'Interactive rebase', 'No nteractive rebase')
+    .addOption('rewrite', 'Will rewrite commit messages with feature as prefix.', 'Will not rewrite commits')
+    .addOption('ff', 'Will run merge with ff-only', 'Will run merge with no-ff')
+    .addOption('squash', 'Will squash commits into 1', 'Will not squash commits into 1')
+    .action(wrap(bugfixClose));
 
   program
     .command('feature-create [branch]')

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -50,21 +50,23 @@ function init() {
     .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
     .action(wrap(hotfixClose));
 
-  program
-    .command('bugfix-create [branch]')
-    .description('Create locally a bugfix branch from latest master')
-    .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
-    .action(wrap(bugfixCreate));
+  if (getConfig().BUGFIX_PREFIX) {
+    program
+      .command('bugfix-create [branch]')
+      .description('Create locally a bugfix branch from latest master')
+      .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
+      .action(wrap(bugfixCreate));
 
-  program
-    .command('bugfix-close [branch]')
-    .description('Close a bugfix branch to master')
-    .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
-    .addOption('interactive', 'Interactive rebase', 'No nteractive rebase')
-    .addOption('rewrite', 'Will rewrite commit messages with feature as prefix.', 'Will not rewrite commits')
-    .addOption('ff', 'Will run merge with ff-only', 'Will run merge with no-ff')
-    .addOption('squash', 'Will squash commits into 1', 'Will not squash commits into 1')
-    .action(wrap(bugfixClose));
+    program
+      .command('bugfix-close [branch]')
+      .description('Close a bugfix branch to master')
+      .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
+      .addOption('interactive', 'Interactive rebase', 'No nteractive rebase')
+      .addOption('rewrite', 'Will rewrite commit messages with feature as prefix.', 'Will not rewrite commits')
+      .addOption('ff', 'Will run merge with ff-only', 'Will run merge with no-ff')
+      .addOption('squash', 'Will squash commits into 1', 'Will not squash commits into 1')
+      .action(wrap(bugfixClose));
+  }
 
   program
     .command('feature-create [branch]')

--- a/src/test/bugfix-create-close-test.ts
+++ b/src/test/bugfix-create-close-test.ts
@@ -1,0 +1,61 @@
+describe('bugfix-create bugfix-close', function() {
+  it('should create bugfix and push to remote', function() {
+    this.oneflow('bugfix-create bugfix-branch -p')
+      .assertLocalContainsBranch('* bugfix-branch')
+      .assertRemoteContainsBranch('bugfix-branch');
+  });
+
+  it('should create bugfix change message and then close it', function() {
+    this.oneflow('bugfix-create bugfix2-branch -p').commit('1st commit');
+    const { commitMsg } = this.getCommit();
+    this.assertLocalContainsBranch('* bugfix2-branch')
+      .oneflow('bugfix-close bugfix2-branch -p -r')
+      .assertLocalContainsBranch('* master')
+      .assertLocalDoesNotContainBranch('bugfix2-branch')
+      .assertRemoteDoesNotContainBranch('bugfix2-branch');
+
+    this.assertLocalCommitMsg(`bugfix2-branch: ${commitMsg}`);
+  });
+
+  it('should create bugfix and then close it', function() {
+    this.oneflow('bugfix-create bugfix3-branch -p').commit('1st commit');
+    const { commitMsg } = this.getCommit();
+    this.assertLocalContainsBranch('* bugfix3-branch')
+      .oneflow('bugfix-close bugfix3-branch -p -R')
+      .assertLocalContainsBranch('* master')
+      .assertLocalDoesNotContainBranch('bugfix3-branch')
+      .assertRemoteDoesNotContainBranch('bugfix3-branch');
+
+    this.assertLocalCommitMsg(commitMsg);
+  });
+
+  it('should create bugfix and then close it with squash', function() {
+    this.oneflow('bugfix-create bugfix4-branch -p').commit('1st commit');
+    const { commit, commitMsg } = this.getCommit();
+    this.commit('2ond commit');
+    const { commit: commit2, commitMsg: commitMsg2 } = this.getCommit();
+
+    this.assertLocalContainsBranch('* bugfix4-branch')
+      .oneflow('bugfix-close bugfix4-branch -p -R -s')
+      .assertLocalContainsBranch('* master')
+      .assertLocalDoesNotContainBranch('bugfix4-branch')
+      .assertRemoteDoesNotContainBranch('bugfix4-branch');
+
+    this.assertLocalCommitMultiLineMsg(
+      `bugfix4-branch\n\n${commit2.substr(0, 7)} ${commitMsg2}\n${commit.substr(0, 7)} ${commitMsg}`
+    );
+  });
+
+  it('should create bugfix and then close it with no-ff-flag', function() {
+    this.oneflow('bugfix-create bugfix5-branch -p').commit('1st commit');
+    const { commitMsg } = this.getCommit();
+    this.assertLocalContainsBranch('* bugfix5-branch')
+      .oneflow('bugfix-close bugfix5-branch -p -r -F')
+      .assertLocalContainsBranch('* master')
+      .assertLocalDoesNotContainBranch('bugfix5-branch')
+      .assertRemoteDoesNotContainBranch('bugfix5-branch');
+
+    this.assertLocalCommitMsg("Merge branch 'bugfix5-branch'");
+    this.assertLocalCommitMsg(`bugfix5-branch: ${commitMsg}`, -1);
+  });
+});

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -36,6 +36,7 @@ FEATURE_CLOSE_SQUASH=false
 RELEASE_CREATE_AND_CLOSE=false
 RELEASE_CLOSE_MERGES_TO_BASE_BRANCH=true
 initialized=true
+BUGFIX_PREFIX=prefix
 `}" >> .oneflowrc && git add . && git commit -m "Added configuration" && git push`
   );
 }


### PR DESCRIPTION
### Bugfix-start, bugfix-close
To avoid seconds thoughts among devs, I think, when opening a bugfix, it would be simpler and clearer to type

`oneflow bugfix-start foo` instead of `oneflow feature-start foo`

Under the hood, it's the same command as `feature-start` :)

### Display help if no arguments given
More than one people, were left wondering for a couple of seconds, if they typed just the `oneflow` command. So, displaying help doesn't harm.

### Copywriting improvements
More elaborate description when running commands