### PR TITLE
Consider only semantic versioning tags as latest tags

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -130,7 +130,7 @@ export async function getBranchPrompt(branch, defaultName?) {
 export async function getTagPrompt(tag, msg, nextRelease?) {
   if (!tag) {
     const latestTagCommit = exec('git rev-list --tags --max-count=1', { log: false });
-    const latestTag = await exec(`git describe --tags ${latestTagCommit}`, { log: false });
+    const latestTag = await exec(`git describe --tags --match "v[0-9]*" ${latestTagCommit}`, { log: false });
     if (nextRelease) {
       tag = (latestTag && latestTag.startsWith('v') ? 'v' : '') + semver.inc(latestTag, nextRelease);
     } else {

--- a/src/lib/hotfix-close.ts
+++ b/src/lib/hotfix-close.ts
@@ -14,7 +14,7 @@ export default async function hotfixClose(branch, tag, options) {
   const config = getConfig(options);
   exec('git fetch origin --tags --prune');
   const latestTagCommit = exec('git rev-list --tags --max-count=1', { log: false });
-  const latestTag = exec(`git describe --tags ${latestTagCommit}`, { log: false });
+  const latestTag = exec(`git describe --tags --match "v[0-9]*" ${latestTagCommit}`, { log: false });
 
   branch = await getBranchPrompt(branch);
   tag = await getTagPrompt(tag, 'create tag?', 'patch');


### PR DESCRIPTION
Oneflow currently prompts the last tag as a base tag, whatever that is. 

This change alters the tag recommendations to consider only semantic versioning tags (`vX.X.X`). 

It doesn't mess with the flow since the user can still input her desired tag.