### PR TITLE
RMV: Error in case merged branch is already deleted

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -104,7 +104,7 @@ export async function pushBranchToRemoteAndDelete(branch, shouldPush?) {
         true
       )
     });
-    exec(`git branch -d ${branch} && git push origin :refs/heads/${branch}`);
+    exec(`git branch -d ${branch} && git push origin :refs/heads/${branch}`, { exit: false });
     return true;
   } else {
     console.log(`Please run: ${chalk.red(


### PR DESCRIPTION
This fix loosens the behaviour of branch deletion skipping the error in case the merged branch is already deleted in the remote repository.

This scenario is critical in case of SCM platforms, like Github, supporting automatic deletion of merged branches.

**Reported Issue**: https://github.com/Workable/oneflow/issues/52