### PR TITLE
Preserve v in tags if latest tag also has a v

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,6 @@ Available options:
 
 ```
   -P, --no-push-flag   Will not push local changes to remote
-  -M, --no-merge-flag  Will not merge after creating tag if called with -c
+  -M, --no-merge-flag  Will not merge after creating tag
   -h, --help           output usage information
 ```

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -101,8 +101,8 @@ function init() {
     .addOption('push', 'Pushes local changes to remote', 'Will not push local changes to remote')
     .addOption(
       'merge',
-      'Will merge after creating tag if called with -c',
-      'Will not merge after creating tag if called with -c'
+      'Will merge after creating tag',
+      'Will not merge after creating tag'
     )
     .action(wrap(releaseClose));
 

--- a/src/test/helpers-test.ts
+++ b/src/test/helpers-test.ts
@@ -17,7 +17,7 @@ describe.skip('helpers', function() {
         .local('git add . && git commit -m "adding version files"')
         .oneflow('release-create master 1.1.0 -p')
         .oneflow('release-close 1.1.0 -p')
-        .assertLocalCommitMsg('[oneflow] prepare for next development iteration 1.2.0-SNAPSHOT')
+        .assertLocalCommitMsg('[oneflow] prepare for next development iteration v1.2.0-SNAPSHOT')
         .assertLocalCommitMsg('[oneflow] v1.1.0', -1);
 
       const { commit: commitOfTag } = this.getCommit('v1.1.0');


### PR DESCRIPTION
Give a backwards compatible way to have source codes without package.json that have tags prefixed with v.